### PR TITLE
feat: 편집 UI 개선

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
     },
   },
   rules: {
+    "no-await-in-loop": "off",
     "react/jsx-no-bind": "off",
     "react/function-component-definition": "off",
     "no-unused-vars": "warn",

--- a/src/features/videoEditor/components/TrimSlider.jsx
+++ b/src/features/videoEditor/components/TrimSlider.jsx
@@ -1,22 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+
 import { Slider } from "antd";
 import PropTypes from "prop-types";
 
-const TrimSlider = ({ trim, duration, onChange }) => {
+const THUMB_W = 60;
+const THUMB_H = 60;
+
+const TrimSlider = ({ width, duration, videoSrc, trim, onChange }) => {
+  const [thumbs, setThumbs] = useState([]);
+  const videoEl = useRef(null);
+  const count = Math.max(8, Math.ceil(width / THUMB_W));
+
+  const formatTime = (sec) => {
+    const h = Math.floor(sec / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    const s = Math.floor(sec % 60);
+
+    return h
+      ? `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`
+      : `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  useEffect(() => {
+    if (!videoSrc || !duration || !width) return;
+
+    const video = document.createElement("video");
+    video.src = videoSrc;
+    video.muted = true;
+    video.crossOrigin = "anonymous";
+    videoEl.current = video;
+
+    const grab = (t) => {
+      return new Promise((res) => {
+        const c = document.createElement("canvas");
+
+        const done = () => {
+          c.width = video.videoWidth;
+          c.height = video.videoHeight;
+          c.getContext("2d").drawImage(video, 0, 0);
+          return res(c.toDataURL("image/jpeg", 0.55));
+        };
+
+        video.currentTime = t;
+        video.addEventListener("seeked", done, { once: true });
+      });
+    };
+
+    const build = async () => {
+      const list = [];
+
+      for (let i = 0; i < count; i += 1) {
+        list.push(await grab((duration * i) / (count - 1)));
+      }
+
+      setThumbs(list);
+    };
+
+    video.addEventListener("loadedmetadata", build, { once: true });
+  }, [videoSrc, duration, width, count]);
+
   return (
-    <Slider
-      range
-      min={0}
-      max={duration || 1}
-      value={trim}
-      onChange={onChange}
-      disabled={duration === 0}
-    />
+    <div
+      className="relative mx-auto select-none"
+      style={{ width, height: THUMB_H }}
+    >
+      <div
+        className="flex overflow-hidden rounded-md w-full h-full"
+        style={{ pointerEvents: "none" }}
+      >
+        {thumbs.map((src) => (
+          <img
+            key={src}
+            src={src}
+            alt="thumb"
+            style={{
+              width: `${100 / count}%`,
+              height: "100%",
+              objectFit: "cover",
+            }}
+          />
+        ))}
+      </div>
+      <Slider
+        range
+        min={0}
+        max={duration || 1}
+        step={0.01}
+        value={trim}
+        onChange={onChange}
+        disabled={!duration}
+        tooltip={{ formatter: formatTime }}
+        styles={{
+          rail: { background: "transparent", height: THUMB_H },
+          track: { background: "rgba(156, 163, 175, 0.5)", height: THUMB_H },
+          handle: { opacity: 0, boxShadow: "none" },
+        }}
+        style={{
+          position: "absolute",
+          inset: 0,
+          padding: 0,
+          margin: 0,
+        }}
+      />
+    </div>
   );
 };
 
 TrimSlider.propTypes = {
-  trim: PropTypes.arrayOf(PropTypes.number).isRequired,
+  width: PropTypes.number.isRequired,
   duration: PropTypes.number.isRequired,
+  videoSrc: PropTypes.string.isRequired,
+  trim: PropTypes.arrayOf(PropTypes.number).isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/features/videoEditor/components/TrimSlider.jsx
+++ b/src/features/videoEditor/components/TrimSlider.jsx
@@ -12,13 +12,13 @@ const TrimSlider = ({ width, duration, videoSrc, trim, onChange }) => {
   const count = Math.max(8, Math.ceil(width / THUMB_W));
 
   const formatTime = (sec) => {
-    const h = Math.floor(sec / 3600);
-    const m = Math.floor((sec % 3600) / 60);
-    const s = Math.floor(sec % 60);
+    const hour = Math.floor(sec / 3600);
+    const minutes = Math.floor((sec % 3600) / 60);
+    const seconds = Math.floor(sec % 60);
 
-    return h
-      ? `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`
-      : `${m}:${s.toString().padStart(2, "0")}`;
+    return hour
+      ? `${hour}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`
+      : `${minutes}:${seconds.toString().padStart(2, "0")}`;
   };
 
   useEffect(() => {
@@ -30,18 +30,19 @@ const TrimSlider = ({ width, duration, videoSrc, trim, onChange }) => {
     video.crossOrigin = "anonymous";
     videoEl.current = video;
 
-    const grab = (t) => {
+    const grab = (time) => {
       return new Promise((res) => {
-        const c = document.createElement("canvas");
+        const canvas = document.createElement("canvas");
 
         const done = () => {
-          c.width = video.videoWidth;
-          c.height = video.videoHeight;
-          c.getContext("2d").drawImage(video, 0, 0);
-          return res(c.toDataURL("image/jpeg", 0.55));
+          canvas.width = video.videoWidth;
+          canvas.height = video.videoHeight;
+          canvas.getContext("2d").drawImage(video, 0, 0);
+
+          return res(canvas.toDataURL("image/jpeg", 0.55));
         };
 
-        video.currentTime = t;
+        video.currentTime = time;
         video.addEventListener("seeked", done, { once: true });
       });
     };

--- a/src/features/videoEditor/components/VideoPlayer.jsx
+++ b/src/features/videoEditor/components/VideoPlayer.jsx
@@ -14,6 +14,8 @@ const VideoPlayer = ({
     <ReactPlayer
       ref={ref}
       url={url}
+      width="1080px"
+      height="640px"
       controls
       playing={playing}
       onDuration={onDuration}


### PR DESCRIPTION
## #️⃣ Issue Number #26

## 🚅 PR 요약

기존 슬라이더의 UI를 변경하여 좀 더 편집툴 느낌이 나게 개선하였습니다.
프레임 시퀀스를 추가하였습니다.

## TO-DO 체크리스트

- [x] 슬라이더의 폭을 조정
- [x] 프레임 시퀀스 UI 추가 
- [x] 슬라이더의 trim 핸들러 보이지 않게 변경

## 🧑‍💻 PR 세부 내용

비디오의 폭을 가져와 프레임 시퀀스 길이를 비디오 폭에 맞췄습니다,
기존 슬라이더 UI에서 세로 길이를 넓히고 불투명 처리를 하여 
편집 툴 느낌이 날 수 있게 개선하였습니다.

📸 스크린샷 
<img src="https://github.com/user-attachments/assets/43c183a0-2779-40c5-ac77-b85d9067f80d" width=500 height=300/>


## 💬 공유사항 to 리뷰어

프레임 시퀀스를 가져오는 로직에서 eslint 에러(no-loop-awiat)가 발생하였습니다.
반복문 안에서 await을 사용하면 성능이 떨어질 수 있다고 확인하였습니다.
video 자체를 복제하여 가져오는 방식도 확인하였으나 메모리 측면에서 좋지 않을 수 있다고
생각되어 eslint 설정을 추가하는 방식으로 변경했습니다.

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
