### PR TITLE
fix: 모달이 최상단에 있지 않아 겹치는 문제 해결 

### DIFF
--- a/src/shared/components/LoadingModal.jsx
+++ b/src/shared/components/LoadingModal.jsx
@@ -1,6 +1,6 @@
 const LoadingModal = () => {
   return (
-    <div className="fixed inset-0 flex justify-center items-center bg-slate-200 bg-opacity-50">
+    <div className="fixed inset-0 z-50 flex justify-center items-center bg-slate-200 bg-opacity-50">
       <div className="rounded-md flex flex-col items-center">
         <div className="grid grid-cols-2 gap-2 mb-4">
           <div className="h-4 w-4 rounded-full bg-gray-400 animate-dot-flip [animation-delay:0ms]" />

--- a/src/shared/components/Modal.jsx
+++ b/src/shared/components/Modal.jsx
@@ -5,7 +5,7 @@ import Button from "./Button";
 
 const Modal = ({ children, onClick, onClose, buttonText = "확인" }) => {
   return (
-    <div className="fixed inset-0 flex justify-center items-center bg-slate-200 bg-opacity-50">
+    <div className="fixed inset-0 z-50 flex justify-center items-center bg-slate-200 bg-opacity-50">
       <div className="py-4 px-6 bg-white rounded-md relative space-y-4">
         <IoCloseOutline
           className="absolute top-2 right-2 text-2xl cursor-pointer"


### PR DESCRIPTION
## #️⃣ Issue Number #34

## 🚅 PR 요약

모달이 다른 요소와 겹치는 문제 해결

## 🧑‍💻 PR 세부 내용

z속성을 주지 않아서 다른 속성과 겹치는 문제가 발생한 것 같아
z-50을 모달에 다 할당하였더니 해결되었습니다.

<img src="https://github.com/user-attachments/assets/2b8c2a16-6b3b-4df7-b85a-ff4dd7b310a2" width=300 height=200/>
<img src="https://github.com/user-attachments/assets/27f51e30-d1d1-4e8a-93d0-856a92437ae1" width=300 height=200/>

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 코드 컨벤션에 맞게 작성했습니다.
