### PR TITLE
feat: 프레임 시퀀스 불러올 때 로딩 띄우기

### DIFF
--- a/src/features/videoEditor/components/TrimSlider.jsx
+++ b/src/features/videoEditor/components/TrimSlider.jsx
@@ -6,7 +6,14 @@ import PropTypes from "prop-types";
 const THUMB_W = 60;
 const THUMB_H = 60;
 
-const TrimSlider = ({ width, duration, videoSrc, trim, onChange }) => {
+const TrimSlider = ({
+  width,
+  duration,
+  videoSrc,
+  trim,
+  onChange,
+  setIsLoading,
+}) => {
   const [thumbs, setThumbs] = useState([]);
   const videoEl = useRef(null);
   const count = Math.max(8, Math.ceil(width / THUMB_W));
@@ -53,7 +60,7 @@ const TrimSlider = ({ width, duration, videoSrc, trim, onChange }) => {
       for (let i = 0; i < count; i += 1) {
         list.push(await grab((duration * i) / (count - 1)));
       }
-
+      setIsLoading(false);
       setThumbs(list);
     };
 
@@ -113,6 +120,7 @@ TrimSlider.propTypes = {
   videoSrc: PropTypes.string.isRequired,
   trim: PropTypes.arrayOf(PropTypes.number).isRequired,
   onChange: PropTypes.func.isRequired,
+  setIsLoading: PropTypes.func.isRequired,
 };
 
 export default TrimSlider;

--- a/src/features/videoSubmit/components/VideoSubmitModal.jsx
+++ b/src/features/videoSubmit/components/VideoSubmitModal.jsx
@@ -36,11 +36,11 @@ const VideoSubmitModal = ({
       setIsLoading(true);
 
       await axios.post("/api/edit", {
+        videoId,
         trimStart: trim[0],
         trimEnd: trim[1],
-        videoId,
-        selectedCharacter,
         email,
+        selectedCharacter,
       });
 
       setIsLoading(false);

--- a/src/pages/VideoEditor.jsx
+++ b/src/pages/VideoEditor.jsx
@@ -8,6 +8,7 @@ import useVideoEditor from "@/features/videoEditor/hooks/useVideoEditor";
 import VideoSubmitModal from "@/features/videoSubmit/components/VideoSubmitModal";
 import Button from "@/shared/components/Button";
 import ErrorModal from "@/shared/components/ErrorModal";
+import LoadingModal from "@/shared/components/LoadingModal";
 
 const VideoEditor = () => {
   const location = useLocation();
@@ -34,6 +35,7 @@ const VideoEditor = () => {
   const videoWrapperRef = useRef(null);
   const [playerWidth, setPlayerWidth] = useState(0);
   const [step, setStep] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (!videoWrapperRef.current) {
@@ -88,6 +90,7 @@ const VideoEditor = () => {
               videoSrc={videoSrc}
               onChange={handleTrimChange}
               width={playerWidth}
+              setIsLoading={setIsLoading}
             />
             <Button onClick={handleEdit}>편집 요청</Button>
           </div>
@@ -103,6 +106,7 @@ const VideoEditor = () => {
           )}
         </div>
       )}
+      {isLoading && <LoadingModal />}
       {error && (
         <ErrorModal onClose={closeError} onClick={closeError} message={error} />
       )}

--- a/src/shared/components/LoadingModal.jsx
+++ b/src/shared/components/LoadingModal.jsx
@@ -1,6 +1,6 @@
 const LoadingModal = () => {
   return (
-    <div className="fixed inset-0 flex justify-center items-center bg-slate-200 bg-opacity-50">
+    <div className="fixed inset-0 z-50 flex justify-center items-center bg-slate-200 bg-opacity-50">
       <div className="rounded-md flex flex-col items-center">
         <div className="grid grid-cols-2 gap-2 mb-4">
           <div className="h-4 w-4 rounded-full bg-gray-400 animate-dot-flip [animation-delay:0ms]" />

--- a/src/shared/components/Modal.jsx
+++ b/src/shared/components/Modal.jsx
@@ -5,7 +5,7 @@ import Button from "./Button";
 
 const Modal = ({ children, onClick, onClose, buttonText = "확인" }) => {
   return (
-    <div className="fixed inset-0 flex justify-center items-center bg-slate-200 bg-opacity-50">
+    <div className="fixed inset-0 z-50 flex justify-center items-center bg-slate-200 bg-opacity-50">
       <div className="py-4 px-6 bg-white rounded-md relative space-y-4">
         <IoCloseOutline
           className="absolute top-2 right-2 text-2xl cursor-pointer"


### PR DESCRIPTION
## #️⃣ Issue Number #36

## 🚅 PR 요약

프레임 시퀀스를 가져올 때 편집 툴에 접근할 수 없도록 로딩 모달 띄우기 

## TO-DO 체크리스트

- [x] 슬라이더에서 Loading 상태 변경

## 🧑‍💻 PR 세부 내용

프레임 정보를 가져오기 전에 편집 툴에 접근했을 때 발생할 수 있는
문제점들을 고려했을 때 로딩을 띄우는 게 맞다고 판단이 되어
로딩 추가했습니다.

📸 스크린샷

<img src="https://github.com/user-attachments/assets/af875365-45db-427e-93bc-123686b55df6" width=300 height=250/>

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
