### PR TITLE
fix: 프레임 정보를 읽는 도중 로딩 모달이 꺼지는 문제 해결

### DIFF
--- a/src/features/videoEditor/components/TrimSlider.jsx
+++ b/src/features/videoEditor/components/TrimSlider.jsx
@@ -60,8 +60,11 @@ const TrimSlider = ({
       for (let i = 0; i < count; i += 1) {
         list.push(await grab((duration * i) / (count - 1)));
       }
-      setIsLoading(false);
-      setThumbs(list);
+
+      if (list.length === count) {
+        setThumbs(list);
+        setIsLoading(false);
+      }
     };
 
     video.addEventListener("loadedmetadata", build, { once: true });


### PR DESCRIPTION
## #️⃣ Issue Number #40

## 🚅 PR 요약

프레임 정보를 다 불러오기 전에 로딩 모달이 꺼지는 문제 해결

## TO-DO 체크리스트

- [x] 가져온 프레임 개수를 따지는 조건문 추가

## 🧑‍💻 PR 세부 내용

개발 환경과 배포 환경의 네트워크 속도의 차이에서
loadedmetadate의 이벤트가 발생하는 시점의 차이가 있었다.
비디오는 여전히 로딩 중인데 loadedmetadata의 이벤트가
발생해서 반복문이 돌고 로딩 모달이 꺼지는 버그가 생겼다. 

## 📍 레퍼런스

참고자료: https://kasterra.github.io/inconsistent-event-firing-with-html5-video

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
